### PR TITLE
radosgw-agent package not required as a dependency for ceph barclamp [1/1]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -29,7 +29,6 @@ debs:
     - ceph-mds
     - ceph-fs-common
     - radosgw
-    - radosgw-agent
     - libcephfs1
     - gdisk
     - cryptsetup


### PR DESCRIPTION
removed radosgw-agent package as a dependency for ceph barclamp

 crowbar.yml |    1 -
 1 file changed, 1 deletion(-)

Crowbar-Pull-ID: 1dbd1c14dd5881a1e2eef5799808bb5535104877

Crowbar-Release: roxy
