### PR TITLE
Make role attributes work, and add some to play around with in CB 2.0 [8/8]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -20,6 +20,13 @@ roles:
     flags:
       - implicit
       - cluster
+    attribs:
+      - name: ceph-fs_uuid
+        description: 'The UUID of the Ceph filesystem this cluster will manage'
+        map: 'ceph/config/fsid'
+      - name: ceph-cluster_name
+        description: 'The name of this Ceph cluster'
+        map: 'ceph/config/name'
   - name: ceph-mon
     jig: chef-solo
     requires:
@@ -27,6 +34,22 @@ roles:
     flags:
       - cluster
       - server
+    attribs:
+      - name: ceph-mon_secret
+        description: "The secret key that Ceph monitors will use to identify each other."
+        map: 'ceph/monitor-secret'
+      - name: ceph-mon-nodes
+        description: 'The list of nodes that will act as ceph monitors'
+        map: 'ceph/monitors'
+      - name: ceph-admin-key
+        description: 'The secret key used to identify the Ceph cluster administrator'
+        map: 'ceph/admin'
+      - name: ceph-mds-key
+        description: 'The secret key used to bootstrap Ceph MDS services'
+        map: 'ceph/bootstrap-mds'
+      - name: ceph-osd-key
+        description: 'The secret key used to bootstrap Ceph OSD services'
+        map: 'ceph/bootstrap-osd'
   - name: ceph-osd
     jig: chef-solo
     requires:


### PR DESCRIPTION
- Make Attrib.get smart. Instead of passing a blob of JSON, it now
  accepts the object it should try to work with. This centralizes the
  logic around what fields in an object are valid places to get
  attributes from, and will fail hard if you pass it something that
  should not work with the attribute system.
- Add matching Attrib.set methods. This provides an abstract interface
  for setting attributes on objects that matches the use of
  Attrib.get.
- Add some attributes to various nodes to lay the groundwork for
  adding logic to the annealer to make it consiter attribute visibility.
- Numerous trivial cleanups to make things work with the above changes.
  
  crowbar.yml | 23 +++++++++++++++++++++++
  1 file changed, 23 insertions(+)

Crowbar-Pull-ID: cd953079fcc42015c6552d4b6d190cc54e898308

Crowbar-Release: development
