### PR TITLE
Colon not allowed after if in ruby19

### DIFF
--- a/crowbar_framework/app/models/ceph_service.rb
+++ b/crowbar_framework/app/models/ceph_service.rb
@@ -51,7 +51,7 @@ class CephService < ServiceObject
 
     # accept proposal with no allocated node -- ie, initial state
     if ((not elements.has_key?("ceph-mon") or elements["ceph-mon"].length == 0) and
-        (not elements.has_key?("ceph-osd") or elements["ceph-osd"].length == 0)):
+        (not elements.has_key?("ceph-osd") or elements["ceph-osd"].length == 0))
        return
     end
 


### PR DESCRIPTION
if (): is an old syntax allowed in ruby 1.8, but not in 1.9. This patch ensures the code is ruby 1.9 - compatible.
