### PR TITLE
[roxy] Clean up bootstrap-osd key permissions

### DIFF
--- a/chef/cookbooks/ceph/recipes/mon.rb
+++ b/chef/cookbooks/ceph/recipes/mon.rb
@@ -123,7 +123,7 @@ unless node['ceph']['encrypted_data_bags']
     block do
       run_out = ""
       while run_out.empty?
-        run_out = Mixlib::ShellOut.new("ceph auth get-or-create-key client.bootstrap-osd").run_command.stdout.strip
+        run_out = Mixlib::ShellOut.new("ceph auth get-key client.bootstrap-osd").run_command.stdout.strip
         sleep 2
       end
       node.normal['ceph']['bootstrap_osd_key'] = run_out

--- a/chef/cookbooks/ceph/recipes/osd.rb
+++ b/chef/cookbooks/ceph/recipes/osd.rb
@@ -116,10 +116,6 @@ else
     creates "/var/lib/ceph/bootstrap-osd/#{cluster}.keyring"
   end
 
-  execute "add bootstrap-osd caps" do
-    command "ceph auth caps client.bootstrap-osd osd 'allow *' mon 'allow *'"
-  end
-
   if is_crowbar?
     if node["ceph"]["osd_devices"].empty?
       unclaimed_disks = BarclampLibrary::Barclamp::Inventory::Disk.unclaimed(node).sort


### PR DESCRIPTION
Don't create a cap without permissions, reassign
global root permissions to them and then hang on waiting
for permissions to be changed.
