### PR TITLE
prevent removing ceph-osd role

### DIFF
--- a/crowbar_framework/app/models/ceph_service.rb
+++ b/crowbar_framework/app/models/ceph_service.rb
@@ -88,6 +88,14 @@ class CephService < ServiceObject
     validate_count_as_odd_for_role proposal, "ceph-mon"
     validate_at_least_n_for_role proposal, "ceph-osd", 2
 
+    osd_nodes = proposal["deployment"]["ceph"]["elements"]["ceph-osd"] || []
+
+    NodeObject.find("roles:ceph-osd").each do |n|
+      unless osd_nodes.include? n.name
+        validation_error "The ceph-osd role cannot be removed from a node '#{n.name}'"
+      end
+    end
+
     super
   end
 end


### PR DESCRIPTION
1. I'm afraid this is not the best solution, don't we have the list of old nodes somewhere, so I don't have to search for them?
2. explanation of why this is needed should be part of commit message. @mjura, could you offer some? Maybe link to the documentation?
