### PR TITLE
Secrets and the fsid should be automatically generated.

### DIFF
--- a/chef/cookbooks/ceph/attributes/default.rb
+++ b/chef/cookbooks/ceph/attributes/default.rb
@@ -1,4 +1,6 @@
 default['ceph']['install_debug'] = true
 default['ceph']['encrypted_data_bags'] = false
+default['ceph']['config']['fsid'] = ""
 default['ceph']['monitor-secret'] = "AQAkTzBSQIGsLRAATtjTpJ1RgdviJz1S0byJBA=="
 default['ceph']['admin-secret'] = "AQAkTzBSmGKZFhAATjC+lKfxOxL1Wn+rgwbWpg=="
+default['ceph']['osd_devices'] = []

--- a/chef/data_bags/crowbar/bc-template-ceph.json
+++ b/chef/data_bags/crowbar/bc-template-ceph.json
@@ -5,11 +5,11 @@
     "ceph": {
       "disk_mode": "first",
       "config": {
-        "fsid" : "11dd315a-2cab-4130-a760-b285324ef622",
+        "fsid" : "",
         "public-network" : "192.168.124.0/24"
       },
-      "monitor-secret": "AQAkTzBSQIGsLRAATtjTpJ1RgdviJz1S0byJBA==",
-      "admin-secret": "AQAkTzBSmGKZFhAATjC+lKfxOxL1Wn+rgwbWpg==",
+      "monitor-secret": "",
+      "admin-secret": "",
       "clustername": "ceph"
     }
   },

--- a/crowbar_framework/app/models/ceph_service.rb
+++ b/crowbar_framework/app/models/ceph_service.rb
@@ -43,6 +43,10 @@ class CephService < ServiceObject
     @logger.debug("Ceph create_proposal: entering")
     base = super
 
+    base["attributes"]["ceph"]["config"]["fsid"] = generate_uuid
+    base["attributes"]["ceph"]["monitor-secret"] = SecureRandom.base64(40)[-40,40]
+    base["attributes"]["ceph"]["admin-secret"] = SecureRandom.base64(40)[-40,40]
+
     nodes        = NodeObject.all
     nodes.delete_if { |n| n.nil? or n.admin? }
 
@@ -89,5 +93,12 @@ class CephService < ServiceObject
     validate_at_least_n_for_role proposal, "ceph-osd", 2
 
     super
+  end
+
+  def generate_uuid
+    ary = SecureRandom.random_bytes(16).unpack("NnnnnN")
+    ary[2] = (ary[2] & 0x0fff) | 0x4000
+    ary[3] = (ary[3] & 0x3fff) | 0x8000
+    "%08x-%04x-%04x-%04x-%04x%08x" % ary
   end
 end


### PR DESCRIPTION
The included patches do the following:
- Remove hardcoded values
- Generates a UUID for the fsid

These values are created at the time the proposal is created.

Signed-off-by: JuanJose 'JJ' Galvez jj.galvez@inktank.com

Conflicts:
    chef/cookbooks/ceph/attributes/default.rb
