### PR TITLE
Secrets and the fsid should be automatically generated.

### DIFF
--- a/chef/cookbooks/ceph/attributes/default.rb
+++ b/chef/cookbooks/ceph/attributes/default.rb
@@ -1,5 +1,6 @@
 default['ceph']['master'] = false
 default['ceph']['install_debug'] = true
+default['ceph']['config']['fsid'] = ""
 default['ceph']['monitor-secret'] = ""
 default['ceph']['admin-secret'] = ""
 default['ceph']['bootstrap-osd-secret'] = ""

--- a/chef/data_bags/crowbar/bc-template-ceph.json
+++ b/chef/data_bags/crowbar/bc-template-ceph.json
@@ -6,7 +6,7 @@
       "master": false,
       "disk_mode": "first",
       "config": {
-        "fsid" : "11dd315a-2cab-4130-a760-b285324ef622",
+        "fsid" : "",
         "public-network" : "192.168.124.0/24"
       },
       "monitor-secret": "",

--- a/crowbar_framework/app/models/ceph_service.rb
+++ b/crowbar_framework/app/models/ceph_service.rb
@@ -43,6 +43,10 @@ class CephService < ServiceObject
     @logger.debug("Ceph create_proposal: entering")
     base = super
 
+    if base["attributes"]["ceph"]["config"]["fsid"].empty?
+      base["attributes"]["ceph"]["config"]["fsid"] = generate_uuid
+    end
+
     nodes        = NodeObject.all
     nodes.delete_if { |n| n.nil? or n.admin? }
 
@@ -122,5 +126,12 @@ class CephService < ServiceObject
     end
 
     super
+  end
+
+  def generate_uuid
+    ary = SecureRandom.random_bytes(16).unpack("NnnnnN")
+    ary[2] = (ary[2] & 0x0fff) | 0x4000
+    ary[3] = (ary[3] & 0x3fff) | 0x8000
+    "%08x-%04x-%04x-%04x-%04x%08x" % ary
   end
 end


### PR DESCRIPTION
The included patches do the following:
- Remove hardcoded values
- Generates a UUID for the fsid
- Generates the values for monitor and admin secret.

These values are created at the time the proposal is created.

Signed-off-by: JuanJose 'JJ' Galvez jj.galvez@inktank.com

Conflicts:
    chef/cookbooks/ceph/attributes/default.rb
