### PR TITLE
Add applied attribute

### DIFF
--- a/chef/data_bags/crowbar/bc-template-ceph.json
+++ b/chef/data_bags/crowbar/bc-template-ceph.json
@@ -17,6 +17,7 @@
   "deployment": {
     "ceph": {
       "crowbar-revision": 0,
+      "crowbar-applied": false,
       "schema-revision": 2,
       "element_states": {
         "ceph-mon": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/bc-template-ceph.schema
+++ b/chef/data_bags/crowbar/bc-template-ceph.schema
@@ -40,6 +40,7 @@
             "crowbar-revision": { "type": "int", "required": true },
             "schema-revision": { "type": "int" },
             "crowbar-committing": { "type": "bool" },
+            "crowbar-applied": { "type": "bool" },
             "crowbar-status": { "type": "str" },
             "crowbar-failed": { "type": "str" },
             "crowbar-queued": { "type": "bool" },

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -33,6 +33,7 @@ crowbar:
   order: 80
   run_order: 80
   chef_order: 80
+  proposal_schema_version: 3
 
 # TODO crowbar *and* chef cookbooks don't really need -dbg
 debs:


### PR DESCRIPTION
We add a crowbar applied attribute to mark the proposal as applied after the chef run. This allows the UI to show that the current form of the proposal has been 'applied' successfully (i.e. chef-client completed the run w/ success) and that the proposal was then not modified.

The second patch adds the proposal_schema_revision, so we can add the attribute to schema for ('3rd party') barclamps that currently do not have it. The crowbar.yml was missing it previously, I'm not sure if this is intentional or not.

Refs: https://github.com/crowbar/crowbar/pull/2044 (which adds this attribute to barclamps which lack it), https://github.com/crowbar/barclamp-crowbar/pull/1068 (which marks the proposals as applied) and https://bugzilla.novell.com/show_bug.cgi?id=877486
