### PR TITLE
Remove updating crush map

### DIFF
--- a/chef/cookbooks/ceph/recipes/osd.rb
+++ b/chef/cookbooks/ceph/recipes/osd.rb
@@ -132,12 +132,6 @@ else
               osd_id = get_osd_id(osd_device['device'])
               sleep 1
             end
-
-            crush_set = Mixlib::ShellOut.new("ceph osd crush set #{osd_id} 1.00 root=default rack=susecloud host=#{node[:hostname]}")
-            crush_set.run_command
-            crush_set.error!
-            Chef::Log.info("Ceph OSD crush map has been updated")
-
           end
         end
         node.set["ceph"]["osd_devices"][index]["status"] = "deployed"


### PR DESCRIPTION
We were doing manual update of crush map after disk activation, this was necessary for older version of Ceph. Since we switched to Ceph Emperor and Firefly crush map is maintained by ceph-disk tool from Ceph package. We should remove this lines in chef osd recipe.
