### PR TITLE
Use the Network barclamp defined networks

### DIFF
--- a/chef/cookbooks/ceph/attributes/conf.rb
+++ b/chef/cookbooks/ceph/attributes/conf.rb
@@ -1,5 +1,3 @@
 default["ceph"]["config"] = {}
 default["ceph"]["config-sections"] = {}
 default["ceph"]["config"]["fsid"] = "11dd315a-2cab-4130-a760-b285324ef622"
-default["ceph"]["config"]["public-network"] = "192.168.124.0/24"
-default["ceph"]["config"]["cluster-network"] = "192.168.125.0/24"

--- a/chef/cookbooks/ceph/recipes/conf.rb
+++ b/chef/cookbooks/ceph/recipes/conf.rb
@@ -8,31 +8,6 @@ mon_nodes.each do |monitor|
     mon_init << monitor.name.split('.')[0]
 end
 
-def mask_to_bits(mask)
-  octets = mask.split(".")
-  count = 0
-  octets.each do |octet|
-    break if octet == "0"
-    c = 1 if octet == "128"
-    c = 2 if octet == "192"
-    c = 3 if octet == "224"
-    c = 4 if octet == "240"
-    c = 5 if octet == "248"
-    c = 6 if octet == "252"
-    c = 7 if octet == "254"
-    c = 8 if octet == "255"
-    count = count + c
-  end
-
-  count
-end
-
-public_mask = mask_to_bits(Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").netmask)
-cluster_mask = mask_to_bits(Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "storage").netmask)
-
-public_network = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").subnet + "/#{public_mask}"
-cluster_network = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "storage").subnet + "/#{cluster_mask}"
-
 directory "/etc/ceph" do
   owner "root"
   group "root"
@@ -45,8 +20,8 @@ template '/etc/ceph/ceph.conf' do
   variables(
     :mon_initial => mon_init,
     :mon_addresses => mon_addresses,
-    :public_network => public_network,
-    :cluster_network => cluster_network
+    :public_network => node["ceph"]["config"]["public-network"],
+    :cluster_network => node["ceph"]["config"]["cluster-network"]
   )
   mode '0644'
 end

--- a/chef/data_bags/crowbar/bc-template-ceph.json
+++ b/chef/data_bags/crowbar/bc-template-ceph.json
@@ -6,8 +6,7 @@
       "master": false,
       "disk_mode": "first",
       "config": {
-        "fsid" : "",
-        "public-network" : "192.168.124.0/24"
+        "fsid" : ""
       },
       "monitor-secret": "",
       "admin-secret": "",
@@ -18,7 +17,7 @@
     "ceph": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 2,
+      "schema-revision": 10,
       "element_states": {
         "ceph-mon": [ "readying", "ready", "applying" ],
         "ceph-osd": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/bc-template-ceph.schema
+++ b/chef/data_bags/crowbar/bc-template-ceph.schema
@@ -18,8 +18,7 @@
               "type": "map",
               "required": true,
               "mapping": {
-                "fsid": { "type": "str", "required": true },
-                "public-network": { "type": "str", "required": true }
+                "fsid": { "type": "str", "required": true }
               }
             },
             "monitor-secret": { "type": "str", "required": true },

--- a/chef/data_bags/crowbar/migrate/ceph/010_remove_overwrites.rb
+++ b/chef/data_bags/crowbar/migrate/ceph/010_remove_overwrites.rb
@@ -1,0 +1,11 @@
+def upgrade ta, td, a, d
+  a["config"].delete("public-network")
+
+  return a, d
+end
+
+def downgrade ta, td, a, d
+  a["config"]["public-network"] = ta["config"]["public-network"]
+
+  return a, d
+end


### PR DESCRIPTION
Instead of having a local copy of network definitions,
import the ones from crowbar directly to have a uniform
and integrated experience (bnc#886197)
