### PR TITLE
Only allocate an IP address on storage network for OSD nodes

### DIFF
--- a/crowbar_framework/app/models/ceph_service.rb
+++ b/crowbar_framework/app/models/ceph_service.rb
@@ -101,7 +101,7 @@ class CephService < ServiceObject
     # Make sure to use the storage network
     net_svc = NetworkService.new @logger
 
-    all_nodes.each do |n|
+    osd_nodes.each do |n|
       net_svc.allocate_ip "default", "storage", "host", n
     end
 


### PR DESCRIPTION
The OSD nodes are the only ones requiring access to it.

http://ceph.com/docs/master/rados/configuration/network-config-ref/
