### PR TITLE
Fix crash on deactivating the ceph proposal

### DIFF
--- a/crowbar_framework/app/models/ceph_service.rb
+++ b/crowbar_framework/app/models/ceph_service.rb
@@ -105,17 +105,19 @@ class CephService < ServiceObject
       net_svc.allocate_ip "default", "storage", "host", n
     end
 
-    # Save net info in attributes
-    node = NodeObject.find_node_by_name all_nodes[0]
-    admin_net = node.get_network_by_type("admin")
-    cluster_net = node.get_network_by_type("storage")
+    # Save net info in attributes if we're applying
+    unless all_nodes.empty?
+      node = NodeObject.find_node_by_name all_nodes[0]
+      admin_net = node.get_network_by_type("admin")
+      cluster_net = node.get_network_by_type("storage")
 
-    role.default_attributes["ceph"]["config"]["public-network"] =
-      "#{admin_net['subnet']}/#{mask_to_bits(admin_net['netmask'])}"
-    role.default_attributes["ceph"]["config"]["cluster-network"] =
-      "#{cluster_net['subnet']}/#{mask_to_bits(cluster_net['netmask'])}"
+      role.default_attributes["ceph"]["config"]["public-network"] =
+        "#{admin_net['subnet']}/#{mask_to_bits(admin_net['netmask'])}"
+      role.default_attributes["ceph"]["config"]["cluster-network"] =
+        "#{cluster_net['subnet']}/#{mask_to_bits(cluster_net['netmask'])}"
 
-    role.save
+      role.save
+    end
 
     # electing master ceph
     unless monitors.empty?


### PR DESCRIPTION
```
F, [2014-07-18T10:02:35.431448 #27874] FATAL -- : apply_role: Exception undefined method `+' for nil:NilClass /opt/dell/crowbar_framework/app/models/node_object.rb:87:in `find_node_by_name'
/opt/dell/crowbar_framework/app/models/ceph_service.rb:109:in `apply_role_pre_chef_call'
/opt/dell/crowbar_framework/app/models/service_object.rb:1212:in `apply_role'
/opt/dell/crowbar_framework/app/models/service_object.rb:569:in `destroy_active'
/opt/dell/crowbar_framework/app/controllers/barclamp_controller.rb:415:in `proposal_update'
```
