### PR TITLE
Fix regression introduced in c51c9c7

### DIFF
--- a/crowbar_framework/app/models/ceph_service.rb
+++ b/crowbar_framework/app/models/ceph_service.rb
@@ -107,7 +107,7 @@ class CephService < ServiceObject
 
     # Save net info in attributes if we're applying
     unless all_nodes.empty?
-      node = NodeObject.find_node_by_name all_nodes[0]
+      node = NodeObject.find_node_by_name osd_nodes[0]
       admin_net = node.get_network_by_type("admin")
       cluster_net = node.get_network_by_type("storage")
 


### PR DESCRIPTION
Not all nodes might be on the storage network anymore, so we could crash
with:

Exception undefined method `[]' for nil:NilClass /opt/dell/crowbar_framework/app/models/ceph_service.rb:117:in`apply_role_pre_chef_call'
/opt/dell/crowbar_framework/app/models/service_object.rb:1213:in `apply_role'
/opt/dell/crowbar_framework/app/models/service_object.rb:1535:in`active_update'
/opt/dell/crowbar_framework/app/models/service_object.rb:726:in `proposal_commit'
/opt/dell/crowbar_framework/app/controllers/barclamp_controller.rb:391:in`proposal_update'
