### PR TITLE
find correct keystone-server 

### DIFF
--- a/chef/cookbooks/ceph/recipes/radosgw_keystone.rb
+++ b/chef/cookbooks/ceph/recipes/radosgw_keystone.rb
@@ -83,7 +83,7 @@ end
 
 keystone_node = search_env_filtered(:node, "roles:keystone-server AND keystone_pki_content:*").first
 
-if !keystone_node.nil? && keystone_node[:keystone][:signing][:token_format] == "PKI"
+if !keystone_node.nil?
   file "#{nss_dir}/keystone_pki_ca.pem" do
     content keystone_node[:keystone][:pki][:content][:ca]
   end


### PR DESCRIPTION
 (also in the HA case, when only the founder has [:pki][:content] values)

https://bugzilla.novell.com/show_bug.cgi?id=891559
