### PR TITLE
Drop bootstrap-osd-secret attribute

### DIFF
--- a/chef/data_bags/crowbar/bc-template-ceph.json
+++ b/chef/data_bags/crowbar/bc-template-ceph.json
@@ -27,7 +27,7 @@
     "ceph": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 13,
+      "schema-revision": 14,
       "element_states": {
         "ceph-mon": [ "readying", "ready", "applying" ],
         "ceph-osd": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/migrate/ceph/014_drop_bootstrap_secret.rb
+++ b/chef/data_bags/crowbar/migrate/ceph/014_drop_bootstrap_secret.rb
@@ -1,0 +1,9 @@
+def upgrade ta, td, a, d
+  a.delete('bootstrap-osd-secret')
+  return a, d
+end
+
+def downgrade ta, td, a, d
+  a['bootstrap-osd-secret'] = ta['bootstrap-osd-secret']
+  return a, d
+end


### PR DESCRIPTION
It's not in the schema anymore, and this breaks migration from roxy.

https://bugzilla.novell.com/show_bug.cgi?id=893827
