### PR TITLE
Fix for default PG settings

### DIFF
--- a/chef/cookbooks/ceph/templates/default/ceph.conf.erb
+++ b/chef/cookbooks/ceph/templates/default/ceph.conf.erb
@@ -26,14 +26,12 @@
         public network = <%= @public_network %>
         cluster network = <%= @cluster_network %>
 
-        osd pool default size = <%= [@osd_nodes_count, 3].min %>
-        # Ensure you have a realistic number of placement groups. We recommend
-        # approximately 100 per OSD. E.g., total number of OSDs multiplied by 100
-        # divided by the number of replicas (i.e., osd pool default size). So for
-        # 10 OSDs and osd pool default size = 4, we'd recommend approximately
-        # (100 * 10) / 4 = 250.
-        osd pool default pg num = <%= (@osd_nodes_count * 10) / [@osd_nodes_count, 3].min %>
-        osd pool default pgp num = <%= (@osd_nodes_count * 10) / [@osd_nodes_count, 3].min %>
+        ; replication level, number of data copies
+        osd pool default size = <%= @pool_size %>
+        ; number of placement groups for a pool
+        osd pool default pg num = <%= @pool_pg_num %>
+        ; default number of placement groups for placement for a pool
+        osd pool default pgp num = <%= @pool_pg_num %>
 
         # Choose a reasonable crush leaf type.
         # 0 for a 1-node cluster.

--- a/chef/data_bags/crowbar/bc-template-ceph.json
+++ b/chef/data_bags/crowbar/bc-template-ceph.json
@@ -6,7 +6,9 @@
       "master": false,
       "disk_mode": "all",
       "config": {
-        "fsid" : ""
+        "fsid" : "",
+        "osds_in_total": 0,
+        "replicas_number": 0
       },
       "monitor-secret": "",
       "admin-secret": "",

--- a/chef/data_bags/crowbar/bc-template-ceph.schema
+++ b/chef/data_bags/crowbar/bc-template-ceph.schema
@@ -18,7 +18,9 @@
               "type": "map",
               "required": true,
               "mapping": {
-                "fsid": { "type": "str", "required": true }
+                "fsid": { "type": "str", "required": true },
+                "osds_in_total": { "type": "int", "required": true },
+                "replicas_number": { "type": "int", "required": true }
               }
             },
             "monitor-secret": { "type": "str", "required": true },

--- a/chef/data_bags/crowbar/migrate/ceph/021_add_replicas_and_osds_number.rb
+++ b/chef/data_bags/crowbar/migrate/ceph/021_add_replicas_and_osds_number.rb
@@ -1,0 +1,11 @@
+def upgrade ta, td, a, d
+  a['config']['osds_in_total'] = ta['config']['osds_in_total']
+  a['config']['replicas_number'] = ta['config']['replicas_number']
+  return a, d
+end
+
+def downgrade ta, td, a, d
+  a['config'].delete('osds_in_total')
+  a['config'].delete('replicas_number')
+  return a, d
+end

--- a/crowbar_framework/app/views/barclamp/ceph/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/ceph/_edit_attributes.html.haml
@@ -4,6 +4,9 @@
 
   .panel-body
     = select_field :disk_mode, :collection => :diskmodes_for_ceph
+    = integer_field %w(config replicas_number), :min => 0, :max => 6
+    %span.help-block
+      = t('.replicas_number_hint')
 
     %fieldset
       %legend

--- a/crowbar_framework/config/locales/ceph/en.yml
+++ b/crowbar_framework/config/locales/ceph/en.yml
@@ -22,6 +22,9 @@ en:
     ceph:
       edit_attributes:
         disk_mode: 'Disk selection method'
+        config:
+          replicas_number: 'Number of replicas of an object'
+        replicas_number_hint: 'Values: 0 - automatic, 1-6 - number of replicas'
         radosgw:
           ssl:
             header: 'SSL Support for RadosGW'


### PR DESCRIPTION
The default PG settings chosen by the barclamp-ceph are really poor for bigger
deployments, since it scales the PGs by number of osd nodes. If the osd node
has many disks or very few disks, these are really off.

https://bugzilla.novell.com/show_bug.cgi?id=896409
