### PR TITLE
In apache 2.4, 'Order' command (used by fastcgi.conf) is provided by mod_access_compat

### DIFF
--- a/chef/cookbooks/ceph/recipes/radosgw_apache2.rb
+++ b/chef/cookbooks/ceph/recipes/radosgw_apache2.rb
@@ -129,6 +129,12 @@ apache_module 'fastcgi' do
   conf true
 end
 
+if node[:platform] == "suse" && node['platform_version'].to_f >= 12
+  apache_module 'access_compat' do
+    conf false
+  end
+end
+
 apache_module 'rewrite' do
   conf false
 end


### PR DESCRIPTION
Maybe we should check for apache version instead of platform version... ?
