### PR TITLE
Fix first_disk nil check, ensure disk_list is array

### DIFF
--- a/chef/cookbooks/ceph/recipes/osd.rb
+++ b/chef/cookbooks/ceph/recipes/osd.rb
@@ -89,7 +89,7 @@ else
             true
           end
         end
-        first_disk      = disk_list.first if first_disk == nil
+        first_disk      = disk_list.first if first_disk.nil?
         disk_list       = [ first_disk ]
       end
     elsif node["ceph"]["disk_mode"] == "all"


### PR DESCRIPTION
first_disk is returned from unclaimed_disks.find, which means it'll either be an instance of Disk or nil, so testing for empty? throws an error (undefined method `empty?' for #<BarclampLibrary::Barclamp::Inventory::Disk::....)

disk_list needs to always be an array - making it an empty string causes the subsequent disk_list.select to throw an error (NoMethodError: private method `select' called for "":String)
