### PR TITLE
Fix ceph deployment after upgarde from Cloud 3

### DIFF
--- a/crowbar_framework/app/models/ceph_service.rb
+++ b/crowbar_framework/app/models/ceph_service.rb
@@ -198,7 +198,7 @@ class CephService < PacemakerServiceObject
       end
     end
 
-    unless proposal["deployment"]["ceph"]["elements"]["ceph-radosgw"].empty?
+    unless radosgw_nodes.empty?
       ProposalObject.find_proposals("swift").each {|p|
         if (p.status == "ready") || (p.status == "pending")
           validation_error("Swift is already deployed. Only one of Ceph with RadosGW and Swift can be deployed at any time.")


### PR DESCRIPTION
proposal["deployment"]["ceph"]["elements"]["ceph-radosgw"] might not always be
a list. So use the already initialized radosgw_nodes variable which is assured
be a (possibly empty) list.

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=899909
