### PR TITLE
Avoid selecting controller nodes for storage

### DIFF
--- a/crowbar_framework/app/models/ceph_service.rb
+++ b/crowbar_framework/app/models/ceph_service.rb
@@ -35,8 +35,12 @@ class CephService < ServiceObject
       controller_nodes = controller_nodes.take(3)
     end
 
+    # Prefer non-storage/non-controller nodes for monitors
+    other_nodes = nodes.dup
+    other_nodes.delete_if { |n| ["storage", "controller"].include? n.intended_role }
+
     if storage_nodes.size < 2
-      storage_nodes = [ storage_nodes, controller_nodes, nodes ].flatten.uniq{|n| n.name}
+      storage_nodes = [ storage_nodes, other_nodes, controller_nodes ].flatten.uniq{|n| n.name}
       storage_nodes = storage_nodes.take(2)
     end
 


### PR DESCRIPTION
If no nodes was specifically selected as storage node,
prefer the non-controller nodes for storage.

Helps with https://bugzilla.novell.com/show_bug.cgi?id=882808

(cherry picked from commit 18ff4cc8cd42f9776d48ef18e716aa80cc114524)
