### PR TITLE
Use region from keystone settings

### DIFF
--- a/chef/cookbooks/ceph/recipes/radosgw_keystone.rb
+++ b/chef/cookbooks/ceph/recipes/radosgw_keystone.rb
@@ -57,7 +57,7 @@ keystone_register "register radosgw endpoint" do
     token keystone_settings['admin_token']
     port keystone_settings['admin_port']
     endpoint_service "swift"
-    endpoint_region "RegionOne"
+    endpoint_region keystone_settings['endpoint_region']
     endpoint_publicURL "#{protocol}://#{public_host}:#{port}/swift/v1"
     endpoint_adminURL "#{protocol}://#{admin_host}:#{port}/swift/v1"
     endpoint_internalURL "#{protocol}://#{admin_host}:#{port}/swift/v1"


### PR DESCRIPTION
The keystone barclamp got the possibility to set a custom region
name. This name must be used by other barclamps as well.

related to: https://bugzilla.novell.com/show_bug.cgi?id=896481
