### PR TITLE
Remove keystone depends

### DIFF
--- a/chef/cookbooks/ceph/metadata.rb
+++ b/chef/cookbooks/ceph/metadata.rb
@@ -7,5 +7,4 @@ long_description	IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version				"0.1.0"
 
 depends                 "apache2"
-depends                 "keystone"
 depends                 "crowbar-pacemaker"


### PR DESCRIPTION
Keystone is a soft dependency (not used if not configured), so remove it
from the depends list, else the ceph barclamp can't be used standalone
without OpenStack.

Signed-off-by: Tim Serong tserong@suse.com
