### PR TITLE
Fix keystone admin url (bnc#907103)

### DIFF
--- a/chef/cookbooks/ceph/templates/default/ceph.conf.erb
+++ b/chef/cookbooks/ceph/templates/default/ceph.conf.erb
@@ -141,7 +141,7 @@
   keyring = /etc/ceph/ceph.client.radosgw.<%= node['hostname'] %>.keyring
   log file = /var/log/radosgw/radosgw.log
   <% unless node[:ceph][:keystone_instance].nil? || node[:ceph][:keystone_instance].empty? -%>
-  rgw keystone url =  <%= @keystone_settings['internal_auth_url'] %>
+  rgw keystone url =  <%= @keystone_settings['admin_auth_url'] %>
   rgw keystone admin token = <%= @keystone_settings['admin_token'] %>
   nss db path = <%= node['ceph']['radosgw']['nss_directory'] %>
   <% end -%>


### PR DESCRIPTION
The internal_auth_url is pointing to something like :5000/v2.0.
Ceph RadosGW appends /v2.0 there which makes it fail to validate
the keystone token. Use the admin url instead which avoids
the issue.

(cherry picked from commit dae79da757a0d58066d67cd5da6c4ce2cc8230ab)
