### PR TITLE
Properly install ceph server and client packages

### DIFF
--- a/chef/cookbooks/ceph/recipes/cinder.rb
+++ b/chef/cookbooks/ceph/recipes/cinder.rb
@@ -1,9 +1,7 @@
 include_recipe "ceph::default"
 include_recipe "ceph::conf"
 
-package "python-ceph" do
-  action :install
-end
+package "python-ceph"
 
 # TODO cluster name
 cluster = 'ceph'

--- a/chef/cookbooks/ceph/recipes/default.rb
+++ b/chef/cookbooks/ceph/recipes/default.rb
@@ -51,7 +51,5 @@ when "suse"
 end
 
 packages.each do |pkg|
-  package pkg do
-    action :install
-  end
+  package pkg
 end

--- a/chef/cookbooks/ceph/recipes/default.rb
+++ b/chef/cookbooks/ceph/recipes/default.rb
@@ -46,8 +46,7 @@ when "redhat", "centos", "fedora"
   end
 when "suse"
   packages = %w{
-      ceph
-      python-ceph
+      ceph-common
   }
 end
 

--- a/chef/cookbooks/ceph/recipes/glance.rb
+++ b/chef/cookbooks/ceph/recipes/glance.rb
@@ -1,9 +1,7 @@
 include_recipe "ceph::default"
 include_recipe "ceph::conf"
 
-package "python-ceph" do
-  action :install
-end
+package "python-ceph"
 
 # TODO cluster name
 cluster = 'ceph'

--- a/chef/cookbooks/ceph/recipes/mon.rb
+++ b/chef/cookbooks/ceph/recipes/mon.rb
@@ -15,6 +15,7 @@
 #  /var/lib/ceph/bootstrap-{osd,mds}/ceph.keyring
 
 include_recipe "ceph::default"
+include_recipe "ceph::server"
 include_recipe "ceph::conf"
 
 service_type = node["ceph"]["mon"]["init_style"]

--- a/chef/cookbooks/ceph/recipes/nova.rb
+++ b/chef/cookbooks/ceph/recipes/nova.rb
@@ -12,9 +12,7 @@ when "suse"
 end
 
 packages.each do |pkg|
-  package pkg do
-    action :install
-  end
+  package pkg
 end
 
 # TODO cluster name

--- a/chef/cookbooks/ceph/recipes/osd.rb
+++ b/chef/cookbooks/ceph/recipes/osd.rb
@@ -35,9 +35,7 @@ include_recipe "ceph::default"
 include_recipe "ceph::server"
 include_recipe "ceph::conf"
 
-package 'gdisk' do
-  action :install
-end
+package 'gdisk'
 
 service_type = node["ceph"]["osd"]["init_style"]
 mons = get_mon_nodes("ceph_bootstrap-osd-secret:*")

--- a/chef/cookbooks/ceph/recipes/osd.rb
+++ b/chef/cookbooks/ceph/recipes/osd.rb
@@ -32,6 +32,7 @@
 #]
 
 include_recipe "ceph::default"
+include_recipe "ceph::server"
 include_recipe "ceph::conf"
 
 package 'gdisk' do

--- a/chef/cookbooks/ceph/recipes/radosgw_apache2.rb
+++ b/chef/cookbooks/ceph/recipes/radosgw_apache2.rb
@@ -31,9 +31,7 @@ case node['platform_family']
 end
 
 packages.each do |pkg|
-  package pkg do
-    action :install
-  end
+  package pkg
 end
 
 

--- a/chef/cookbooks/ceph/recipes/radosgw_keystone.rb
+++ b/chef/cookbooks/ceph/recipes/radosgw_keystone.rb
@@ -68,9 +68,7 @@ crowbar_pacemaker_sync_mark "create-radosgw_register"
 
 # Convert OpenSSL certificates that Keystone uses for creating the requests to the nss db format
 # See http://ceph.com/docs/master/radosgw/keystone/
-package "mozilla-nss-tools" do
-  action :install
-end
+package "mozilla-nss-tools"
 
 nss_dir = node['ceph']['radosgw']['nss_directory']
 

--- a/chef/cookbooks/ceph/recipes/server.rb
+++ b/chef/cookbooks/ceph/recipes/server.rb
@@ -2,8 +2,6 @@
 
 case node[:platform]
 when "suse"
-  package "ceph" do
-    action :install
-  end
+  package "ceph"
 end
 

--- a/chef/cookbooks/ceph/recipes/server.rb
+++ b/chef/cookbooks/ceph/recipes/server.rb
@@ -1,0 +1,9 @@
+
+
+case node[:platform]
+when "suse"
+  package "ceph" do
+    action :install
+  end
+end
+


### PR DESCRIPTION
On SLE12, ceph was split into ceph-common (client parts of
the package) and "ceph" (including the server part and depending
on the client). Install the packages appropriately as
the ceph server is removed from SLE11.