### PR TITLE
Fix compatibility with Swift client (bnc#915753)

### DIFF
--- a/chef/cookbooks/ceph/templates/default/rgw.conf.erb
+++ b/chef/cookbooks/ceph/templates/default/rgw.conf.erb
@@ -11,6 +11,7 @@ FastCgiExternalServer <%= node['ceph']['radosgw']['path'] %>/s3gw.fcgi -socket /
   ServerAlias <%= node["crowbar"]["display"]["alias"] %>
 <% end -%>
   DocumentRoot <%= node['ceph']['radosgw']['path'] %>
+  LimitRequestFieldSize 32768
 
   RewriteEngine On
   RewriteCond %{REQUEST_URI} !^/server-status


### PR DESCRIPTION
The swift client is passing in the keystone token, which is
significantly larger than the default maximum header size.