### PR TITLE
 radosgw: Use X-Forwarded-For IP address in logs when behind haproxy

### DIFF
--- a/chef/cookbooks/ceph/templates/default/rgw.conf.erb
+++ b/chef/cookbooks/ceph/templates/default/rgw.conf.erb
@@ -40,7 +40,12 @@ FastCgiExternalServer <%= node['ceph']['radosgw']['path'] %>/s3gw.fcgi -socket /
   AllowEncodedSlashes On
 
   ErrorLog <%= node['apache']['log_dir'] %>/rgw-error_log
+  <% if @behind_proxy -%>
+  LogFormat "%{X-Forwarded-For}i %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" proxy_combined
   CustomLog <%= node['apache']['log_dir'] %>/rgw-access_log proxy_combined
+  <% else -%>
+  CustomLog <%= node['apache']['log_dir'] %>/rgw-access_log combined
+  <% end -%>
   ServerSignature Off
 </VirtualHost>
 <% if @node[:ceph][:radosgw][:ssl][:enabled] -%>


### PR DESCRIPTION
This is much more useful than logging the IP address of the haproxy
server.

This depends on https://github.com/crowbar/barclamp-pacemaker/pull/171