### PR TITLE
Only deal with pacemaker resources on the founder node (bnc#918104)

### DIFF
--- a/chef/cookbooks/ceph/recipes/radosgw_ha.rb
+++ b/chef/cookbooks/ceph/recipes/radosgw_ha.rb
@@ -37,11 +37,13 @@ pacemaker_primitive service_name do
   agent node[:ceph][:ha][:radosgw][:agent]
   op    node[:ceph][:ha][:radosgw][:op]
   action :create
+  only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 pacemaker_clone "cl-#{service_name}" do
   rsc service_name
   action [ :create, :start ]
+  only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 include_recipe "crowbar-pacemaker::apache"


### PR DESCRIPTION
There's no real point in having all nodes try to update all pacemaker
resources all the time, and it actually can lead to issues due to races
when two non-founder nodes try to update the resource at the same time.

It's worth mentioning that for service LWRP, we actually want to do a
:start on each run to ensure that the service is restarted in case it
crashed. For pacemaker resources, the :start doesn't need to be done all
the time: as a crash of the service is caught by pacemaker already. So
if the founder goes missing, this won't hurt us.

http://bugzilla.suse.com/show_bug.cgi?id=918104