### PR TITLE
Fix use_ssd_for_journal edge cases

### DIFF
--- a/chef/data_bags/crowbar/bc-template-ceph.json
+++ b/chef/data_bags/crowbar/bc-template-ceph.json
@@ -4,7 +4,7 @@
   "attributes": {
     "ceph": {
       "master": false,
-      "disk_mode": "first",
+      "disk_mode": "all",
       "config": {
         "fsid" : ""
       },


### PR DESCRIPTION
There's a few odd edge cases with different settings for disk_mode and use_ssd_for_journal:

* If you've only got one disk, and you're using SSDs, that disk ends up being allocated as a journal with no OSD.
* Using disk_mode == first doesn't work with SSDs (again, you get a single journal and no OSD).
* On a system with all SSDs, you end up with only journals, and no OSDs.

This set of commits makes the following changes in order to remedy the above:

1. Default disk_mode to "all" (no real world deployment is ever going to want to only allocate the first disk and no others in a storage node).
2. If someone really wants to use disk_mode == "first", just allocate the first disk as an OSD, regardless of whether it's an SSD or HDD.
3. When first deploying, if the node only has one type of disk, set use_ssd_for_journal to false for that node (so you just get OSDs).