### PR TITLE
Only use disks bigger than 20GB (bnc#886795)

### DIFF
--- a/chef/cookbooks/ceph/recipes/osd.rb
+++ b/chef/cookbooks/ceph/recipes/osd.rb
@@ -68,7 +68,8 @@ else
 
   if is_crowbar?
     node.set["ceph"]["osd_devices"] = [] if node["ceph"]["osd_devices"].nil?
-    unclaimed_disks = BarclampLibrary::Barclamp::Inventory::Disk.unclaimed(node).sort
+    min_size_blocks = node["ceph"]["osd"]["min_size_gb"] * 1024 * 1024 * 2
+    unclaimed_disks = BarclampLibrary::Barclamp::Inventory::Disk.unclaimed(node).sort.select {|d| d.size >= min_size_blocks}
 
     # if devices for journal are explicitely listed, do not use automatic journal assigning to SSD
     if !node["ceph"]["osd"]["journal_devices"].empty?

--- a/chef/data_bags/crowbar/bc-template-ceph.json
+++ b/chef/data_bags/crowbar/bc-template-ceph.json
@@ -13,6 +13,7 @@
       "clustername": "ceph",
       "keystone_instance": "none",
       "osd": {
+        "min_size_gb": 20,
         "journal_size"  : 5120,
         "journal_devices"  : [],
         "use_ssd_for_journal"  : true
@@ -37,7 +38,7 @@
     "ceph": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 20,
+      "schema-revision": 21,
       "element_states": {
         "ceph-calamari": [ "readying", "ready", "applying" ],
         "ceph-mon": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/bc-template-ceph.schema
+++ b/chef/data_bags/crowbar/bc-template-ceph.schema
@@ -29,6 +29,7 @@
               "type": "map",
               "required": true,
               "mapping": {
+                  "min_size_gb": { "type" : "int", "required" : true },
                   "use_ssd_for_journal": { "type" : "bool", "required" : true },
                   "journal_size": { "type" : "int", "required" : true },
                   "journal_devices"  : {

--- a/chef/data_bags/crowbar/migrate/ceph/021_min_osd_size.rb
+++ b/chef/data_bags/crowbar/migrate/ceph/021_min_osd_size.rb
@@ -1,0 +1,9 @@
+def upgrade ta, td, a, d
+  a['osd']['min_size_gb'] = ta['osd']['min_size_gb']
+  return a, d
+end
+
+def downgrade ta, td, a, d
+  a['osd'].delete('min_size_gb')
+  return a, d
+end

--- a/crowbar_framework/app/models/ceph_service.rb
+++ b/crowbar_framework/app/models/ceph_service.rb
@@ -289,19 +289,22 @@ class CephService < PacemakerServiceObject
       end
     end
 
+    min_size_gb = proposal["attributes"]["ceph"]["osd"]["min_size_gb"]
+    min_size_blocks = min_size_gb * 1024 * 1024 * 2
+
     nodes_without_suitable_drives = proposal["deployment"][@bc_name]["elements"]["ceph-osd"].select do |node_name|
       node = NodeObject.find_node_by_name(node_name)
       if node.nil?
           false
       else
-          disks_count = node.unclaimed_physical_drives.length
+          disks_count = node.unclaimed_physical_drives.select { |d, data| data['size'].to_i >= min_size_blocks }.length
           disks_count += node.physical_drives.select { |d, data| node.disk_owner(node.unique_device_for(d)) == 'Ceph' }.length
           disks_count == 0
       end
     end
 
     unless nodes_without_suitable_drives.empty?
-      validation_error("Nodes #{nodes_without_suitable_drives.to_sentence} for ceph-osd role are missing at least one unclaimed disk")
+      validation_error("Nodes #{nodes_without_suitable_drives.to_sentence} for ceph-osd role are missing at least one unclaimed disk larger than #{min_size_gb}GB")
     end
 
     super


### PR DESCRIPTION
Disks 10GB or less result in weighting errors.  5GB is used for the
journal by default, so 20GB seems the safest minium to run with.  Note
that real-world deployments will be unlikely to attempt to use disks
this small for OSDs, but it's not uncommon to run into problems with
small disks when testing toy clusters on virtual machines, which is why
we're now enforcing a minimum size.

Signed-off-by: Tim Serong <tserong@suse.com>