### PR TITLE
Don't use mon user and secret anymore for managing auth settings

### DIFF
--- a/chef/cookbooks/ceph/providers/client.rb
+++ b/chef/cookbooks/ceph/providers/client.rb
@@ -48,28 +48,27 @@ def file_content
 end
 
 def get_key(ceph_conf, admin_keyring, keyname)
-  cmd = "ceph -k #{admin_keyring} -c #{ceph_conf} auth print_key #{keyname} --name mon. --key='#{mon_secret}'"
+  cmd = "ceph -k #{admin_keyring} -c #{ceph_conf} auth print_key #{keyname}"
   Mixlib::ShellOut.new(cmd).run_command.stdout
 end
 
 def get_caps(ceph_conf, admin_keyring, keyname)
   caps = {}
-  cmd = "ceph -k #{admin_keyring} -c #{ceph_conf} auth get #{keyname} --name mon. --key='#{mon_secret}'"
+  cmd = "ceph -k #{admin_keyring} -c #{ceph_conf} auth get #{keyname}"
   output = Mixlib::ShellOut.new(cmd).run_command.stdout
   output.scan(/caps\s*(\S+)\s*=\s*"([^"]*)"/) { |k, v| caps[k] = v }
   caps
 end
 
 def auth_set_key(ceph_conf, admin_keyring, keyname, caps)
-  secret = mon_secret
   # try to add the key
-  cmd = "ceph -k #{admin_keyring} -c #{ceph_conf} auth get-or-create #{keyname} #{caps} --name mon. --key='#{secret}'"
+  cmd = "ceph -k #{admin_keyring} -c #{ceph_conf} auth get-or-create #{keyname} #{caps}"
   get_or_create = Mixlib::ShellOut.new(cmd)
   get_or_create.run_command
   if get_or_create.stderr.scan(/EINVAL.*but cap.*does not match/)
     Chef::Log.info('Deleting old key with incorrect caps')
     # delete an old key if it exists and is wrong
-    Mixlib::ShellOut.new("ceph -k #{admin_keyring} -c #{ceph_conf} auth del #{keyname} --name mon. --key='#{secret}'").run_command
+    Mixlib::ShellOut.new("ceph -k #{admin_keyring} -c #{ceph_conf} auth del #{keyname}").run_command
     # try to create again
     get_or_create = Mixlib::ShellOut.new(cmd)
     get_or_create.run_command


### PR DESCRIPTION
The cookbook rely on chef search to find the mon secret. This doesn't work when
using an external ceph cluster (in which case there might even be no mon user).

Additionally, since we're specifying the admin key now for the ceph_client resource
adding additional --name and --key options seems superfluous.