### PR TITLE
Avoid invalid search query when no mon or osd roles are found

### DIFF
--- a/chef/cookbooks/ceph/libraries/default.rb
+++ b/chef/cookbooks/ceph/libraries/default.rb
@@ -10,6 +10,8 @@ def get_mon_nodes(extra_search=nil)
     mon_roles = search(:role, 'name:crowbar-* AND run_list:role\[ceph-mon\]')
     if not mon_roles.empty?
       search_string = mon_roles.map { |role_object| "roles:"+role_object.name }.join(' OR ')
+    else
+      return []
     end
   else
     search_string = "roles:ceph-mon AND chef_environment:#{node.chef_environment}"
@@ -131,6 +133,8 @@ def get_osd_nodes()
     osd_roles = search(:role, 'name:crowbar-* AND run_list:role\[ceph-osd\]')
     if not osd_roles.empty?
       search_string = osd_roles.map { |role_object| "roles:"+role_object.name }.join(' OR ')
+    else
+      return []
     end
   else
     search_string = "roles:ceph-osd AND chef_environment:#{node.chef_environment}"


### PR DESCRIPTION
Note this is an (almost) blind fix. Not sure if this is correct. But endless while loop in ```mon_secret``` should surely be addressed.