### PR TITLE
Do not install the kvm-rbd-plugin package on SLES11

### DIFF
--- a/chef/cookbooks/ceph/recipes/nova.rb
+++ b/chef/cookbooks/ceph/recipes/nova.rb
@@ -3,10 +3,6 @@ include_recipe "ceph::keyring"
 case node[:platform]
 when "suse"
   package "python-ceph"
-  package "kvm-rbd-plugin" do
-    action :install
-    only_if { node[:platform_version].to_f < 12.0 }
-  end
   package "qemu-block-rbd" do
     action :install
     only_if { node[:platform_version].to_f >= 12.0 }


### PR DESCRIPTION
With the ceph client-side support entering SLES11, this feature is now
part of the kvm package directly and there's no kvm-rbd-plugin
subpackage anymore.