### PR TITLE
Do not install the kvm-rbd-plugin package on SLES11

### DIFF
--- a/chef/cookbooks/ceph/recipes/nova.rb
+++ b/chef/cookbooks/ceph/recipes/nova.rb
@@ -7,7 +7,6 @@ case node[:platform]
 when "suse"
   packages = %w{
       python-ceph
-      kvm-rbd-plugin
   }
 end
 


### PR DESCRIPTION
With the ceph client-side support entering SLES11, this feature is now
part of the kvm package directly and there's no kvm-rbd-plugin
subpackage anymore.

(cherry picked from commit 58ca0e7c844e4cd29e22982882ecaafd91a2f823)