### PR TITLE
Correctly handle wrong fsid attribute and allow redefining the libvirt secret

### DIFF
--- a/chef/cookbooks/ceph/recipes/nova.rb
+++ b/chef/cookbooks/ceph/recipes/nova.rb
@@ -24,7 +24,7 @@ if cinder_controller.length > 0
     cinder_pools << volume[:rbd][:pool]
   end
 
-  nova_uuid = node["ceph"]["config"]["fsid"]
+  nova_uuid = is_crowbar? ? "" : node["ceph"]["config"]["fsid"]
   nova_user = 'nova'
 
   if nova_uuid.nil? || nova_uuid.empty?

--- a/chef/cookbooks/ceph/recipes/nova.rb
+++ b/chef/cookbooks/ceph/recipes/nova.rb
@@ -98,13 +98,15 @@ if cinder_controller.length > 0
         client_key = %x[ ceph auth get-key client.'#{nova_user}' ]
         raise 'getting nova client key failed' unless $?.exitstatus == 0
 
-        %x[ virsh secret-define --file '#{secret_file_path}' ]
-        raise 'generating secret file failed' unless $?.exitstatus == 0
+        secret = %x[ virsh secret-get-value #{nova_uuid} 2> /dev/null ].chomp.strip
+        if secret != client_key
+          %x[ virsh secret-define --file '#{secret_file_path}' ]
+          raise 'generating secret file failed' unless $?.exitstatus == 0
 
-        %x[ virsh secret-set-value --secret '#{nova_uuid}' --base64 '#{client_key}' ]
-        raise 'importing secret file failed' unless $?.exitstatus == 0
+          %x[ virsh secret-set-value --secret '#{nova_uuid}' --base64 '#{client_key}' ]
+          raise 'importing secret file failed' unless $?.exitstatus == 0
+        end
       end
-
     end
   end
 

--- a/chef/cookbooks/ceph/recipes/nova.rb
+++ b/chef/cookbooks/ceph/recipes/nova.rb
@@ -24,9 +24,9 @@ if cinder_controller.length > 0
     cinder_pools << volume[:rbd][:pool]
   end
 
-  nova_uuid = is_crowbar? ? "" : node["ceph"]["config"]["fsid"]
   nova_user = 'nova'
 
+  nova_uuid = is_crowbar? ? "" : node["ceph"]["config"]["fsid"]
   if nova_uuid.nil? || nova_uuid.empty?
     mons = get_mon_nodes("ceph_admin-secret:*")
     if mons.empty? then


### PR DESCRIPTION
We had the case where a compute node had some bogus fsid attribute, totally breaking its ceph setup for nova. The solution is to forcefully use the fsid attribute of the mon when crowbar is used.

However, before we can do that, we also need to allow redefining the libvirt secret, as until now, it was not possible to change it.

https://bugzilla.suse.com/show_bug.cgi?id=923224