### PR TITLE
[stoney] Correctly handle wrong fsid attribute and allow redefining the libvirt secret

### DIFF
--- a/chef/cookbooks/ceph/recipes/nova.rb
+++ b/chef/cookbooks/ceph/recipes/nova.rb
@@ -86,6 +86,40 @@ if cinder_controller.length > 0
   ruby_block "save nova key as libvirt secret" do
     block do
       if system("virsh hostname &> /dev/null")
+        # First remove conflicting secrets due to same usage name
+        secret_list = %x[ virsh secret-list 2> /dev/null ]
+
+        secret_lines = secret_list.split("\n")
+        if secret_lines.length < 2 || !secret_lines[0].start_with?("UUID") || !secret_lines[1].start_with?("----")
+          raise "cannot fetch list of libvirt secret"
+        end
+        secret_lines.shift(2)
+
+        secret_lines.each do |secret_line|
+          secret_uuid = secret_line.split(" ")[0]
+          secret_xml = %x[ virsh secret-dumpxml #{secret_uuid} ]
+          # some secrets might not be ceph-related, skip these
+          next if secret_xml.index("<usage type='ceph'>").nil?
+
+          # lazy xml parsing
+          re_match = %r[<usage type='ceph'>.*<name>(.*)</name>]m.match(secret_xml)
+          next if re_match.nil?
+          secret_usage = re_match[1]
+
+          undefine = false
+
+          if secret_uuid == nova_uuid
+            undefine = true if secret_usage != "client.#{nova_user} secret"
+          else
+            undefine = true if secret_usage == "client.#{nova_user} secret"
+          end
+
+          if undefine
+            %x[ virsh secret-undefine #{secret_uuid} ]
+          end
+        end
+
+        # Now add our secret and its value
         client_key = %x[ ceph auth get-key client.'#{nova_user}' ]
         raise 'getting nova client key failed' unless $?.exitstatus == 0
 

--- a/chef/cookbooks/ceph/recipes/nova.rb
+++ b/chef/cookbooks/ceph/recipes/nova.rb
@@ -123,13 +123,15 @@ if cinder_controller.length > 0
         client_key = %x[ ceph auth get-key client.'#{nova_user}' ]
         raise 'getting nova client key failed' unless $?.exitstatus == 0
 
-        %x[ virsh secret-define --file '#{secret_file_path}' ]
-        raise 'generating secret file failed' unless $?.exitstatus == 0
+        secret = %x[ virsh secret-get-value #{nova_uuid} 2> /dev/null ].chomp.strip
+        if secret != client_key
+          %x[ virsh secret-define --file '#{secret_file_path}' ]
+          raise 'generating secret file failed' unless $?.exitstatus == 0
 
-        %x[ virsh secret-set-value --secret '#{nova_uuid}' --base64 '#{client_key}' ]
-        raise 'importing secret file failed' unless $?.exitstatus == 0
+          %x[ virsh secret-set-value --secret '#{nova_uuid}' --base64 '#{client_key}' ]
+          raise 'importing secret file failed' unless $?.exitstatus == 0
+        end
       end
-
     end
   end
 

--- a/chef/cookbooks/ceph/recipes/nova.rb
+++ b/chef/cookbooks/ceph/recipes/nova.rb
@@ -49,7 +49,7 @@ if cinder_controller.length > 0
     cinder_pools << volume[:rbd][:pool]
   end
 
-  nova_uuid = node["ceph"]["config"]["fsid"]
+  nova_uuid = is_crowbar? ? "" : node["ceph"]["config"]["fsid"]
   nova_user = 'nova'
 
   if nova_uuid.nil? || nova_uuid.empty?

--- a/chef/cookbooks/ceph/recipes/nova.rb
+++ b/chef/cookbooks/ceph/recipes/nova.rb
@@ -49,9 +49,9 @@ if cinder_controller.length > 0
     cinder_pools << volume[:rbd][:pool]
   end
 
-  nova_uuid = is_crowbar? ? "" : node["ceph"]["config"]["fsid"]
   nova_user = 'nova'
 
+  nova_uuid = is_crowbar? ? "" : node["ceph"]["config"]["fsid"]
   if nova_uuid.nil? || nova_uuid.empty?
     mons = get_mon_nodes("ceph_admin-secret:*")
     if mons.empty? then


### PR DESCRIPTION
Backport of https://github.com/crowbar/barclamp-ceph/pull/145

We had the case where a compute node had some bogus fsid attribute, totally breaking its ceph setup for nova. The solution is to forcefully use the fsid attribute of the mon when crowbar is used.

However, before we can do that, we also need to allow redefining the libvirt secret, as until now, it was not possible to change it.

https://bugzilla.suse.com/show_bug.cgi?id=923224