### PR TITLE
Fix deployment of radosgw when on a non-osd/mon node

### DIFF
--- a/chef/cookbooks/ceph/recipes/radosgw.rb
+++ b/chef/cookbooks/ceph/recipes/radosgw.rb
@@ -1,5 +1,7 @@
 include_recipe "ceph::default"
 include_recipe "ceph::conf"
+# needed because of our use of ceph_client
+include_recipe "ceph::keyring"
 
 node['ceph']['radosgw']['packages'].each do |pkg|
   package pkg


### PR DESCRIPTION
The use of the ceph_client resource means that we need the admin
keyring, and if the role is deployed on a node that has nothing else
ceph-related, then this currently fails because nothing creates the
keyring.