### PR TITLE
Make member of suse_enterprise_storage

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -23,6 +23,7 @@ barclamp:
   user_managed: true
   member:
     - 'openstack'
+    - 'suse_enterprise_storage'
 
 crowbar:
   layout: 1


### PR DESCRIPTION
This makes the Ceph barclamp a member of both openstack and
suse_enterprise_storage, so it'll appear in the correct group for both
SUSE OpenStack Cloud and SUSE Enterprise Storage deploys.

Signed-off-by: Tim Serong <tserong@suse.com>