### PR TITLE
Fixing missing mon[ceph][admin-secret] keyring on radosgw node, (bnc#…

### DIFF
--- a/chef/cookbooks/ceph/recipes/radosgw.rb
+++ b/chef/cookbooks/ceph/recipes/radosgw.rb
@@ -1,7 +1,11 @@
-include_recipe "ceph::default"
-include_recipe "ceph::conf"
-# needed because of our use of ceph_client
-include_recipe "ceph::keyring"
+# do not include "ceph::keyring" recipe, 
+# when node role is "ceph-mon"
+if node.roles.include?("ceph-mon")
+  include_recipe "ceph::default"
+  include_recipe "ceph::conf"
+else
+  include_recipe "ceph::keyring"
+end
 
 node['ceph']['radosgw']['packages'].each do |pkg|
   package pkg


### PR DESCRIPTION
…930542)

(cherry picked from commit 7a59fb6c4102b3a5731ed5c0d02fe09a21a71367)

https://bugzilla.suse.com/show_bug.cgi?id=930542