### PR TITLE
radosgw: Fix RA of radosgw

### DIFF
--- a/chef/cookbooks/ceph/attributes/radosgw.rb
+++ b/chef/cookbooks/ceph/attributes/radosgw.rb
@@ -58,7 +58,7 @@ default['ceph']['radosgw']['ssl']['generate_certs'] = false
 default['ceph']['radosgw']['ssl']['insecure'] = false
 
 default['ceph']['ha']['radosgw']['enabled'] = false
-default['ceph']['ha']['radosgw']['agent'] = "lsb:#{default['ceph']['radosgw']['service_name']}"
+default['ceph']['ha']['radosgw']['agent'] = "systemd:#{default['ceph']['radosgw']['service_name']}"
 default['ceph']['ha']['radosgw']['op']['monitor']['interval'] = '10s'
 default['ceph']['ha']['ports']['radosgw_plain'] = 5590
 default['ceph']['ha']['ports']['radosgw_ssl'] = 5591


### PR DESCRIPTION
With the move to SLE12, there's no LSB script used anymore and the RA
must be using the systemd service file now.