### PR TITLE
Add config default attributes into conf.rb

### DIFF
--- a/chef/cookbooks/ceph/attributes/conf.rb
+++ b/chef/cookbooks/ceph/attributes/conf.rb
@@ -1,3 +1,5 @@
 default["ceph"]["config"] = {}
 default["ceph"]["config-sections"] = {}
 default["ceph"]["config"]["fsid"] = "11dd315a-2cab-4130-a760-b285324ef622"
+default["ceph"]["config"]["osds_in_total"] = 0
+default["ceph"]["config"]["replicas_number"] = 0


### PR DESCRIPTION
Add config default attributes into conf.rb

ceph/attributes/conf.rb

default["ceph"]["config"]["osds_in_total"] = 0
default["ceph"]["config"]["replicas_number"] = 0

Fixing https://bugzilla.suse.com/show_bug.cgi?id=934064