### PR TITLE
Add support for deploying Calamari with HTTPS (bsc#915315)

### DIFF
--- a/chef/cookbooks/ceph/templates/default/calamari-httpd.conf.erb
+++ b/chef/cookbooks/ceph/templates/default/calamari-httpd.conf.erb
@@ -1,0 +1,71 @@
+<% if @node[:ceph][:calamari][:ssl][:enabled] -%>
+<IfDefine SSL>
+<IfDefine !NOSSL>
+
+<% end -%>
+WSGISocketPrefix /var/run/wsgi
+<IfModule !wsgi_module>
+    LoadModule wsgi_module modules/mod_wsgi.so
+</IfModule>
+
+<VirtualHost *:<%= @port %>>
+    ServerName calamari
+    DocumentRoot "/srv/www/calamari"
+    ErrorLog /var/log/calamari/httpd_error.log
+    CustomLog /var/log/calamari/httpd_access.log common
+    AddOutputFilterByType DEFLATE text/text text/html text/plain text/xml text/css application/x-javascript application/javascript application/json
+
+    <% if @node[:ceph][:calamari][:ssl][:enabled] %>
+    SSLEngine on
+    SSLCertificateFile <%= node['ceph']['calamari']['ssl']['certfile'] %>
+    SSLCertificateKeyFile <%= node['ceph']['calamari']['ssl']['keyfile'] %>
+    <% end %>
+
+    WSGIScriptAlias / /srv/www/calamari/calamari.wsgi
+    WSGIDaemonProcess calamari display-name=calamari-httpd processes=8 threads=1 maximum-requests=32
+    WSGIProcessGroup calamari
+    WSGIApplicationGroup %{GLOBAL}
+
+    # The logic assets are treated as public/static files, and are served
+    # directly by Apache.
+    Alias /static /srv/www/calamari/content/
+    <Location "/static/">
+        <IfVersion >= 2.4>
+            Require all granted
+        </IfVersion>
+        SetHandler None
+    </Location>
+
+    # FIXME: graphite static assets are hardcoded to /content/
+    Alias /content /srv/www/calamari/content/
+    <Location "/content/">
+        <IfVersion >= 2.4>
+            Require all granted
+        </IfVersion>
+        SetHandler None
+    </Location>
+
+    Alias /login/ /srv/www/calamari/content/login/
+    <Location "/login/">
+        <IfVersion >= 2.4>
+            Require all granted
+        </IfVersion>
+        SetHandler None
+    </Location>
+
+    <Directory /srv/www/calamari>
+        <IfVersion >= 2.4>
+            Require all granted
+        </IfVersion>
+        <IfVersion < 2.4>
+            Order deny,allow
+            Allow from all
+        </IfVersion>
+    </Directory>
+
+</VirtualHost>
+<% if @node[:ceph][:calamari][:ssl][:enabled] -%>
+</IfDefine>
+</IfDefine>
+
+<% end -%>

--- a/chef/data_bags/crowbar/bc-template-ceph.json
+++ b/chef/data_bags/crowbar/bc-template-ceph.json
@@ -32,7 +32,12 @@
       "calamari": {
         "username": "admin",
         "email": "admin@example.com",
-        "password": "calamari"
+        "password": "calamari",
+        "ssl": {
+          "enabled": false,
+          "certfile": "/etc/apache2/ssl.crt/calamari-server.crt",
+          "keyfile": "/etc/apache2/ssl.key/calamari-server.key"
+        }
       }
     }
   },
@@ -40,7 +45,7 @@
     "ceph": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 30,
+      "schema-revision": 31,
       "element_states": {
         "ceph-calamari": [ "readying", "ready", "applying" ],
         "ceph-mon": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/bc-template-ceph.schema
+++ b/chef/data_bags/crowbar/bc-template-ceph.schema
@@ -64,7 +64,16 @@
               "mapping": {
                 "username": { "type": "str", "required": true },
                 "email": { "type": "str", "required": true },
-                "password": { "type": "str", "required": true }
+                "password": { "type": "str", "required": true },
+                "ssl": {
+                  "type": "map",
+                  "required": true,
+                  "mapping": {
+                    "enabled": { "type" : "bool", "required" : true },
+                    "certfile": { "type" : "str", "required" : true },
+                    "keyfile": { "type" : "str", "required" : true }
+                  }
+                }
               }
             }
           }

--- a/chef/data_bags/crowbar/migrate/ceph/031_add_calamari_ssl.rb
+++ b/chef/data_bags/crowbar/migrate/ceph/031_add_calamari_ssl.rb
@@ -1,0 +1,9 @@
+def upgrade ta, td, a, d
+  a['calamari']['ssl'] = ta['calamari']['ssl']
+  return a, d
+end
+
+def downgrade ta, td, a, d
+  a['calamari'].delete('ssl')
+  return a, d
+end

--- a/crowbar_framework/app/helpers/barclamp/ceph_helper.rb
+++ b/crowbar_framework/app/helpers/barclamp/ceph_helper.rb
@@ -35,5 +35,14 @@ module Barclamp
         selected.to_s
       )
     end
+    def calamari_ssl_protocols(selected)
+      options_for_select(
+        [
+          ["HTTP", "false"],
+          ["HTTPS", "true"]
+        ],
+        selected.to_s
+      )
+    end
   end
 end

--- a/crowbar_framework/app/views/barclamp/ceph/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/ceph/_edit_attributes.html.haml
@@ -27,3 +27,13 @@
       = string_field %w(calamari username)
       = string_field %w(calamari email)
       = password_field %w(calamari password)
+
+      %fieldset
+        %legend
+          = t(".calamari.ssl.header")
+
+        = boolean_field %w(calamari ssl enabled), :collection => :calamari_ssl_protocols, "data-sslprefix" => "calamari_ssl", "data-sslcert" => "/etc/apache2/ssl.crt/calamari-server.crt", "data-sslkey" => "/etc/apache2/ssl.key/calamari-server.key"
+
+        #calamari_ssl_container
+          = string_field %w(calamari ssl certfile)
+          = string_field %w(calamari ssl keyfile)

--- a/crowbar_framework/config/locales/ceph/en.yml
+++ b/crowbar_framework/config/locales/ceph/en.yml
@@ -38,3 +38,8 @@ en:
           username: 'Administrator Username'
           email: 'Administrator Email Address'
           password: 'Administrator Password'
+          ssl:
+            header: 'SSL Support for Calamari'
+            enabled: 'Protocol'
+            certfile: 'SSL Certificate File'
+            keyfile: 'SSL (Private) Key File'


### PR DESCRIPTION
Note that this change causes the barclamp to replace
/etc/apache2/conf.d/calamari.conf as shipped in the calamari-server
pacakge.  This should be fine as that file is %config(noreplace) in the
calamari-server specfile, so won't be clobbered if calamari-server is
upgraded later.

Signed-off-by: Tim Serong <tserong@suse.com>