### PR TITLE
Dedicated ceph-client network, (FATE#319122)

### DIFF
--- a/chef/cookbooks/ceph/libraries/default.rb
+++ b/chef/cookbooks/ceph/libraries/default.rb
@@ -80,7 +80,7 @@ def get_mon_addresses()
 
     mons += get_mon_nodes()
     if is_crowbar?
-      mon_ips = mons.map { |node| Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address }
+      mon_ips = mons.map { |node| Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "storage").address }
     else
       if node['ceph']['config'] && node['ceph']['config']['public-network']
         mon_ips = mons.map { |nodeish| find_node_ip_in_network(node['ceph']['config']['public-network'], nodeish) }

--- a/chef/cookbooks/ceph/recipes/conf.rb
+++ b/chef/cookbooks/ceph/recipes/conf.rb
@@ -75,8 +75,6 @@ template '/etc/ceph/ceph.conf' do
     :pool_size => rep_num,
     :pool_pg_num => pg_num,
     :osd_nodes_count => osd_nodes.length,
-    :public_network => node["ceph"]["config"]["public-network"],
-    :cluster_network => node["ceph"]["config"]["cluster-network"],
     :is_rgw => is_rgw,
     :keystone_settings => keystone_settings
   )

--- a/chef/cookbooks/ceph/templates/default/ceph.conf.erb
+++ b/chef/cookbooks/ceph/templates/default/ceph.conf.erb
@@ -23,8 +23,10 @@
         mon host = <%= @mon_addresses.join(', ') %>    
         
         ; configure a public and cluster network
-        public network = <%= @public_network %>
-        cluster network = <%= @cluster_network %>
+        public network = <%= node["ceph"]["config"]["public-network"] %>
+        <% unless node["ceph"]["config"]["cluster-network"].nil? -%>
+        cluster network = <%= node["ceph"]["config"]["cluster-network"] %>
+        <% end -%>
 
         ; replication level, number of data copies
         osd pool default size = <%= @pool_size %>


### PR DESCRIPTION
This is initial PR for creating dedicated ceph-client network. We use `admin` network as ceph client network which is totally wrong, because mostly `admin` network is limited with 100Mb/s or 1Gb/s interfaces. Clients would like to have separate physical networks with 10Gb/s interfaces for ceph clients and separate network for ceph osd's replication.

Proposal is to use default `storage` network as ceph client network and allow to add new network called `replication` which will be used for ceph backend replication.

Problems to solved:
- we have figure out how to migrate old cluster to new network setup

WARNING!!! Please do not merge this PR.
